### PR TITLE
[ENH] Enforce original order of sessions from input

### DIFF
--- a/proc_dash/app.py
+++ b/proc_dash/app.py
@@ -228,6 +228,7 @@ app.layout = html.Div(
     children=[
         navbar,
         dcc.Store(id="memory-filename"),
+        dcc.Store(id="memory-sessions"),
         dcc.Store(id="memory-overview"),
         dcc.Store(id="memory-pipelines"),
         html.Div(
@@ -341,6 +342,7 @@ def toggle_dataset_name_dialog(
 @app.callback(
     [
         Output("memory-filename", "data"),
+        Output("memory-sessions", "data"),
         Output("memory-overview", "data"),
         Output("memory-pipelines", "data"),
         Output("upload-message", "children"),
@@ -388,6 +390,7 @@ def process_bagel(contents, filename, memory_filename):
             no_update,
             None,
             None,
+            None,
             "Upload a CSV file to begin.",
             no_update,
             no_update,
@@ -406,6 +409,7 @@ def process_bagel(contents, filename, memory_filename):
             schema=ctx.triggered_id.index,
         )
         if upload_error is None:
+            session_list = bagel["session"].unique().tolist()
             overview_df = util.get_pipelines_overview(
                 bagel=bagel, schema=ctx.triggered_id.index
             )
@@ -419,6 +423,7 @@ def process_bagel(contents, filename, memory_filename):
     if upload_error is not None:
         return (
             filename,
+            None,
             None,
             None,
             f"Error: {upload_error} Please try again.",
@@ -438,6 +443,7 @@ def process_bagel(contents, filename, memory_filename):
 
     return (
         filename,
+        session_list,
         {
             "type": ctx.triggered_id.index,
             "data": overview_df.to_dict("records"),
@@ -458,18 +464,20 @@ def process_bagel(contents, filename, memory_filename):
         Output("session-filter-form", "style"),
     ],
     Input("memory-overview", "data"),
+    State("memory-sessions", "data"),
     prevent_initial_update=True,
 )
-def update_session_filter(parsed_data):
+def update_session_filter(parsed_data, session_list):
     """When uploaded data changes, update the unique session options and visibility of the session filter dropdown."""
     if parsed_data is None:
         return [], {"display": "none"}
 
-    overview_df = pd.DataFrame.from_dict(parsed_data.get("data"))
-    sessions = (
-        overview_df["session"].unique().tolist()
-    )  # preserve original order of sessions
-    session_opts = [{"label": ses, "value": ses} for ses in sessions]
+    # TODO: Revisit
+    # overview_df = pd.DataFrame.from_dict(parsed_data.get("data"))
+    # sessions = (
+    #     overview_df["session"].unique().tolist()
+    # )
+    session_opts = [{"label": ses, "value": ses} for ses in session_list]
 
     return session_opts, {"display": "block"}
 
@@ -627,9 +635,10 @@ def reset_selections(filename):
         Output("processing-status-legend", "style"),
     ],
     Input("memory-overview", "data"),
+    State("memory-sessions", "data"),
     prevent_initial_call=True,
 )
-def generate_overview_status_fig_for_participants(parsed_data):
+def generate_overview_status_fig_for_participants(parsed_data, session_list):
     """
     If new dataset uploaded, generate stacked bar plot of pipeline_complete statuses per session,
     grouped by pipeline. Provides overview of the number of participants with each status in a given session,
@@ -638,7 +647,7 @@ def generate_overview_status_fig_for_participants(parsed_data):
     if parsed_data is not None and parsed_data.get("type") != "phenotypic":
         return (
             plot.plot_pipeline_status_by_participants(
-                pd.DataFrame.from_dict(parsed_data.get("data"))
+                pd.DataFrame.from_dict(parsed_data.get("data")), session_list
             ),
             {"display": "block"},
             {"display": "block"},

--- a/proc_dash/app.py
+++ b/proc_dash/app.py
@@ -466,7 +466,9 @@ def update_session_filter(parsed_data):
         return [], {"display": "none"}
 
     overview_df = pd.DataFrame.from_dict(parsed_data.get("data"))
-    sessions = overview_df["session"].sort_values().unique().tolist()
+    sessions = (
+        overview_df["session"].unique().tolist()
+    )  # preserve original order of sessions
     session_opts = [{"label": ses, "value": ses} for ses in sessions]
 
     return session_opts, {"display": "block"}

--- a/proc_dash/plotting.py
+++ b/proc_dash/plotting.py
@@ -33,7 +33,9 @@ def transform_active_data_to_long(data: pd.DataFrame) -> pd.DataFrame:
     )
 
 
-def plot_pipeline_status_by_participants(data: pd.DataFrame):
+def plot_pipeline_status_by_participants(
+    data: pd.DataFrame, session_list: list
+):
     status_counts = (
         transform_active_data_to_long(data)
         .groupby(["pipeline_name", "pipeline_complete", "session"])
@@ -50,7 +52,7 @@ def plot_pipeline_status_by_participants(data: pd.DataFrame):
         facet_col="pipeline_name",
         category_orders={
             "pipeline_complete": PIPELINE_STATUS_ORDER,
-            "session": data["session"].unique(),
+            "session": session_list,
         },
         color_discrete_map=STATUS_COLORS,
         labels={

--- a/proc_dash/plotting.py
+++ b/proc_dash/plotting.py
@@ -48,7 +48,10 @@ def plot_pipeline_status_by_participants(data: pd.DataFrame):
         color="pipeline_complete",
         text_auto=True,
         facet_col="pipeline_name",
-        category_orders={"pipeline_complete": PIPELINE_STATUS_ORDER},
+        category_orders={
+            "pipeline_complete": PIPELINE_STATUS_ORDER,
+            "session": data["session"].unique(),
+        },
         color_discrete_map=STATUS_COLORS,
         labels={
             "pipeline_name": "Pipeline",

--- a/proc_dash/utility.py
+++ b/proc_dash/utility.py
@@ -81,7 +81,7 @@ def extract_pipelines(bagel: pd.DataFrame, schema: str) -> dict:
     sort = bool(schema == "imaging")
 
     groupby = get_event_id_columns(bagel, schema)
-    # groupby auto-sorts keys (columns), but not actual column values
+    # We only want to sort columns (when needed), not the values inside them. .groupby(sort=True) achieves this
     pipelines = bagel.groupby(by=groupby, sort=sort)
 
     if isinstance(groupby, list):
@@ -124,9 +124,7 @@ def are_subjects_same_across_pipelines(
     for df in pipelines_dict.values():
         # per pipeline, rows are sorted first in case participants/sessions are out of order
         pipeline_subject_sessions.append(
-            df.sort_values(["participant_id", "session"]).loc[
-                :, get_id_columns(bagel)
-            ]
+            df.sort_values(get_id_columns(bagel)).loc[:, get_id_columns(bagel)]
         )
 
     return all(


### PR DESCRIPTION
<!---
Until this PR is ready for review, you can include the [WIP] tag in its title, or leave it as a github draft.
-->






<!---
This is a suggested pull request template.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue
when this pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.

You can also just link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->


<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers
to indicate what they should be looking for when they review the pull request.
-->
Changes proposed in this pull request:

Since the `session` column is read as type `str`, this PR removes any explicit sorting of sessions in user-facing elements (e.g., order of session dropdown, axis labels) **and** enforces the order of appearance of unique sessions in the input data where sorting was previously happening implicitly (looking at you `pandas.DataFrame.pivot`).

This prevents both undesirable sorting of numeric sessions (e.g., `"1"`, `"11"`, `"5"`) and of session labels that have chronological meaning (e.g., `"intake"` comes before `"follow-up"`).

Explicit session sorting is now only used when checking that the same participants and sessions exist across pipelines.

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted
