### PR TITLE
[ENH] Re-enable native datatable filtering UI

### DIFF
--- a/proc_dash/app.py
+++ b/proc_dash/app.py
@@ -179,10 +179,7 @@ def update_session_filter(parsed_data, session_list):
 
 
 @app.callback(
-    [
-        Output("pipeline-dropdown-container", "children"),
-        Output("interactive-datatable", "style_filter_conditional"),
-    ],
+    Output("pipeline-dropdown-container", "children"),
     Input("memory-pipelines", "data"),
     State("memory-overview", "data"),
     prevent_initial_call=True,
@@ -216,16 +213,7 @@ def create_pipeline_status_dropdowns(pipelines_dict, parsed_data):
         )
         pipeline_dropdowns.append(new_pipeline_status_dropdown)
 
-    # "session" column filter is also disabled due to implemented dropdown filters for session
-    style_disabled_filters = [
-        {
-            "if": {"column_id": c},
-            "pointer-events": "None",
-        }
-        for c in list(pipelines_dict.keys()) + ["session"]
-    ]
-
-    return pipeline_dropdowns, style_disabled_filters
+    return pipeline_dropdowns
 
 
 @app.callback(

--- a/proc_dash/layout.py
+++ b/proc_dash/layout.py
@@ -244,10 +244,8 @@ def advanced_filter_form_title():
             ),
             dbc.Tooltip(
                 dcc.Markdown(
-                    """
-                Filter for multiple sessions simultaneously.
-                Note that any data filters selected here will always be applied *before* any column filter(s) specified directly in the data table.
-                """
+                    "Filter for multiple sessions simultaneously. "
+                    "Note that any data filters selected here will always be applied *before* any column filter(s) specified directly in the data table."
                 ),
                 target="tooltip-question-target",
             ),

--- a/proc_dash/layout.py
+++ b/proc_dash/layout.py
@@ -243,8 +243,12 @@ def advanced_filter_form_title():
                 id="tooltip-question-target",
             ),
             dbc.Tooltip(
-                "Filter for multiple sessions simultaneously. "
-                "Any filter specified directly in the data table will be applied on top of the advanced filtering.",
+                dcc.Markdown(
+                    """
+                Filter for multiple sessions simultaneously.
+                Note that any data filters selected here will always be applied *before* any column filter(s) specified directly in the data table.
+                """
+                ),
                 target="tooltip-question-target",
             ),
         ],


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #81

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Built-in datatable filtering enabled again for all columns to give user option to use either the column filter UI or the independent dropdown filters (for more complex queries)
- Tooltip for advanced filtering dropdowns updated to be (hopefully) clearer about how the native datatable filtering and dropdown filtering interact

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
