### PR TITLE
[FIX] Re-infer column dtypes for dataframes processed from input files

### DIFF
--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pandas as pd
 import pytest
 
 import proc_dash.utility as util
@@ -15,3 +17,27 @@ def test_invalid_filetype_returns_informative_error(filename):
 
     assert bagel is None
     assert "Invalid file type" in upload_error
+
+
+def test_reset_column_dtypes():
+    """
+    Test that reset_column_dtypes() infers more appropriate dtypes for columns whose values were erroneously stored as strings,
+    and that the 'session' column is always converted to strings (object dtype).
+    """
+    pheno_overview_df = pd.DataFrame(
+        {
+            "participant_id": ["sub-1", "sub-2", "sub-3"],
+            "session": [1, 1, 1],
+            "group": ["PD", "PD", "PD"],
+            "moca_total": ["21", "24", np.nan],
+            "moca_total_status": ["true", "true", "false"],
+        }
+    )
+
+    pheno_overview_df_retyped = util.reset_column_dtypes(pheno_overview_df)
+
+    assert pheno_overview_df_retyped["participant_id"].dtype == "object"
+    assert pheno_overview_df_retyped["session"].dtype == "object"
+    assert pheno_overview_df_retyped["group"].dtype == "object"
+    assert pheno_overview_df_retyped["moca_total"].dtype == "float64"
+    assert pheno_overview_df_retyped["moca_total_status"].dtype == "bool"


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #93 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Helper function added to re-infer more appropriate dtypes of columns with type `object` due to being derived from a mixed-dtype column. This is done via a workaround that leverages the type inference of pandas `read_csv` (see also #93 issue description)

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
