### PR TITLE
[ENH] Generate column value summary card for a selected phenotypic column

### DIFF
--- a/proc_dash/app.py
+++ b/proc_dash/app.py
@@ -469,7 +469,7 @@ def generate_column_summary(
     column_data = pd.DataFrame.from_dict(virtual_data)[selected_column]
     return (
         selected_column,
-        util.construct_column_summary_str(column_data),
+        util.generate_column_summary_str(column_data),
         {"display": "block"},
     )
 

--- a/proc_dash/layout.py
+++ b/proc_dash/layout.py
@@ -348,7 +348,7 @@ def column_summary_card():
                 ),
                 html.P(
                     id="column-summary",
-                    style={"whiteSpace": "pre"},
+                    style={"whiteSpace": "pre-wrap"},  # preserve newlines
                     className="card-text",
                 ),
             ],
@@ -447,9 +447,9 @@ def construct_layout():
                         ),
                         width=8,
                     ),
-                    # TODO: Try and center card within column vertically
                     dbc.Col(column_summary_card()),
                 ],
+                align="center",
             ),
         ],
         style={"padding": "10px 10px 10px 10px"},

--- a/proc_dash/layout.py
+++ b/proc_dash/layout.py
@@ -337,6 +337,27 @@ def phenotypic_plotting_form():
     )
 
 
+def column_summary_card():
+    """Generates the card that displays summary statistics about a selected phenotypic column."""
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H5(
+                    id="column-summary-title",
+                    className="card-title",
+                ),
+                html.P(
+                    id="column-summary",
+                    style={"whiteSpace": "pre"},
+                    className="card-text",
+                ),
+            ],
+        ),
+        id="column-summary-card",
+        style={"display": "none"},
+    )
+
+
 def construct_layout():
     """Generates the overall dashboard layout."""
     return html.Div(
@@ -418,13 +439,17 @@ def construct_layout():
                 ],
             ),
             dbc.Row(
-                dbc.Col(
-                    dcc.Graph(
-                        id="fig-column-histogram",
-                        style={"display": "none"},
+                [
+                    dbc.Col(
+                        dcc.Graph(
+                            id="fig-column-histogram",
+                            style={"display": "none"},
+                        ),
+                        width=8,
                     ),
-                    width=8,
-                )
+                    # TODO: Try and center card within column vertically
+                    dbc.Col(column_summary_card()),
+                ],
             ),
         ],
         style={"padding": "10px 10px 10px 10px"},

--- a/proc_dash/utility.py
+++ b/proc_dash/utility.py
@@ -42,42 +42,6 @@ def reset_column_dtypes(data: pd.DataFrame) -> pd.DataFrame:
     return data_retyped
 
 
-def construct_column_summary_str(column: pd.Series) -> str:
-    """
-    Compute and return summary statistics for a given column as a string.
-    For a numerical column, these include the non-missing and missing value counts, mean, standard deviation, min, median, and max.
-    For a categorical column, these include the non-missing and missing value counts, number of unique values, and most common value.
-    """
-    if np.issubdtype(column.dtype, np.number):
-        # Define summary stats we don't care about. We ignore 'count' because we recompute this value as a ratio below.
-        ignore_stats = ["25%", "75%", "count"]
-        summary_stats = (
-            column.describe().rename({"50%": "median"}).map("{:.2f}".format)
-        )
-    else:
-        ignore_stats = ["freq", "count"]
-        summary_stats = column.describe().rename(
-            {"unique": "unique values", "top": "most common value"}
-        )
-
-    summary_stats = pd.concat(
-        [
-            pd.Series(
-                {
-                    "non-missing values": f"{column.notna().sum()}/{len(column)}",
-                    "missing values": f"{column.isna().sum()}/{len(column)}",
-                }
-            ),
-            summary_stats,
-        ],
-    )
-
-    summary_str = summary_stats.drop(labels=ignore_stats).to_csv(
-        header=False, sep="\t"
-    )
-    return summary_str.replace("\t", ": ")
-
-
 def construct_legend_str(status_desc: dict) -> str:
     """From a dictionary, constructs a legend-style string with multiple lines in the format of key: value."""
     return "\n".join(
@@ -328,3 +292,39 @@ def filter_records(
     data = data.query(query)
 
     return data
+
+
+def generate_column_summary_str(column: pd.Series) -> str:
+    """
+    Compute and return summary statistics for a given column as a string.
+    For a numerical column, these include the non-missing and missing value counts, mean, standard deviation, min, median, and max.
+    For a categorical column, these include the non-missing and missing value counts, number of unique values, and most common value.
+    """
+    if np.issubdtype(column.dtype, np.number):
+        # Define summary stats we don't care about. We ignore 'count' because we recompute this value as a ratio below.
+        ignore_stats = ["25%", "75%", "count"]
+        summary_stats = (
+            column.describe().rename({"50%": "median"}).map("{:.2f}".format)
+        )
+    else:
+        ignore_stats = ["freq", "count"]
+        summary_stats = column.describe().rename(
+            {"unique": "unique values", "top": "most common value"}
+        )
+
+    summary_stats = pd.concat(
+        [
+            pd.Series(
+                {
+                    "non-missing values": f"{column.notna().sum()}/{len(column)}",
+                    "missing values": f"{column.isna().sum()}/{len(column)}",
+                }
+            ),
+            summary_stats,
+        ],
+    )
+
+    summary_str = summary_stats.drop(labels=ignore_stats).to_csv(
+        header=False, sep="\t"
+    )
+    return summary_str.replace("\t", ": ")

--- a/proc_dash/utility.py
+++ b/proc_dash/utility.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Optional, Tuple, Union
 
+import numpy as np
 import pandas as pd
 
 SCHEMAS_PATH = Path(__file__).absolute().parents[1] / "schemas"
@@ -39,6 +40,42 @@ def reset_column_dtypes(data: pd.DataFrame) -> pd.DataFrame:
     # Just in case, convert session labels back to strings (will avoid sessions being undesirably treated as continuous data in e.g., plots)
     data_retyped["session"] = data_retyped["session"].astype(str)
     return data_retyped
+
+
+def construct_column_summary_str(column: pd.Series) -> str:
+    """
+    Compute and return summary statistics for a given column as a string.
+    For a numerical column, these include the non-missing and missing value counts, mean, standard deviation, min, median, and max.
+    For a categorical column, these include the non-missing and missing value counts, number of unique values, and most common value.
+    """
+    if np.issubdtype(column.dtype, np.number):
+        # Define summary stats we don't care about. We ignore 'count' because we recompute this value as a ratio below.
+        ignore_stats = ["25%", "75%", "count"]
+        summary_stats = (
+            column.describe().rename({"50%": "median"}).map("{:.2f}".format)
+        )
+    else:
+        ignore_stats = ["freq", "count"]
+        summary_stats = column.describe().rename(
+            {"unique": "unique values", "top": "most common value"}
+        )
+
+    summary_stats = pd.concat(
+        [
+            pd.Series(
+                {
+                    "non-missing values": f"{column.notna().sum()}/{len(column)}",
+                    "missing values": f"{column.isna().sum()}/{len(column)}",
+                }
+            ),
+            summary_stats,
+        ],
+    )
+
+    summary_str = summary_stats.drop(labels=ignore_stats).to_csv(
+        header=False, sep="\t"
+    )
+    return summary_str.replace("\t", ": ")
 
 
 def construct_legend_str(status_desc: dict) -> str:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -128,12 +128,12 @@ def test_003_upload_invalid_phenotypic_bagel(test_server, bagels_path):
     ), "browser console should contain no error"
 
 
-def test_004_phenotypic_col_plotting_selection_generates_histogram(
+def test_004_phenotypic_col_selection_generates_visualization(
     test_server, bagels_path
 ):
     """
     Given a valid phenotypic bagel, displays a dropdown that, in response to a column option selection,
-    displays a histogram for that column without errors.
+    displays a histogram and a value summary card for that column without errors.
     """
     upload = test_server.driver.find_element(
         "xpath",
@@ -159,8 +159,14 @@ def test_004_phenotypic_col_plotting_selection_generates_histogram(
     test_server.wait_for_style_to_equal(
         "#fig-column-histogram", "display", "block", timeout=4
     )
+    test_server.wait_for_style_to_equal(
+        "#column-summary-card", "display", "block", timeout=4
+    )
     assert (
         "moca_total" in test_server.find_element("#fig-column-histogram").text
+    )
+    assert (
+        "moca_total" in test_server.find_element("#column-summary-card").text
     )
 
     assert (

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -58,3 +58,40 @@ def test_wrap_df_column_values():
     wrapped_df = plot.wrap_df_column_values(df, "updrs_p3_hy", 30)
     assert all("<br>" in value for value in wrapped_df["updrs_p3_hy"][1:3])
     assert "<br>" not in wrapped_df["updrs_p3_hy"][0]
+
+
+@pytest.mark.parametrize(
+    "column,nonmissing,missing,stats",
+    [
+        ("group", "3/3", "0/3", ["unique values", "most common value"]),
+        ("moca_total", "2/3", "1/3", ["mean", "std", "min", "median", "max"]),
+        (
+            "moca_total_status",
+            "3/3",
+            "0/3",
+            ["mean", "std", "min", "median", "max"],
+        ),
+    ],
+)
+def test_generate_column_summary_str(column, nonmissing, missing, stats):
+    """Test that generate_column_summary_str() returns a string with the correct summary statistics for a given column."""
+    pheno_overview_df = pd.DataFrame(
+        {
+            "participant_id": ["sub-1", "sub-2", "sub-3"],
+            "session": [
+                "1",
+                "1",
+                "1",
+            ],  # the session column is always converted to strings for the dashboard
+            "group": ["PD", "PD", "PD"],
+            "moca_total": [21, 24, np.nan],
+            "moca_total_status": [True, True, False],
+        }
+    )
+    column_summary = util.generate_column_summary_str(
+        pheno_overview_df[column]
+    )
+
+    assert [stat in column_summary for stat in stats]
+    assert f"non-missing values: {nonmissing}" in column_summary
+    assert f"missing values: {missing}" in column_summary


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #96

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- New utility function and card component added that will compute and display relevant summary stats for a selected column based on the column type
- The card updates according to the active datatable view (filtering-responsive)
- Added test for new utility function and a basic check of the card component

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
